### PR TITLE
Deployment on OpenShift: iot-sse-server service port is incorrect

### DIFF
--- a/services/iot-sse-server/openshift/svc.yml
+++ b/services/iot-sse-server/openshift/svc.yml
@@ -13,7 +13,7 @@ spec:
   - name: 8080-tcp
     port: 8080
     protocol: TCP
-    targetPort: 8081
+    targetPort: 8080
   selector:
     app: iot-sse-server
     deploymentconfig: iot-sse-server


### PR DESCRIPTION
related to https://github.com/RedHat-Middleware-Workshops/rhtr-2020-api-mgmt-kafka-workshop/issues/8
